### PR TITLE
htmlgenerator_2017-05-29_ajuste_carta_resposta

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
@@ -21,8 +21,12 @@
         <xsl:apply-templates select=".//front-stub//contrib-group | .//front//contrib-group"></xsl:apply-templates>
     </xsl:template>
     
+    <xsl:template match="front/contrib-group | front-stub/contrib-group" mode="modal-id"><xsl:value-of select="../../@id"/></xsl:template>
+    <xsl:template match="article-meta/contrib-group | sub-article[@article-type='translation']//contrib-group" mode="modal-id">    
+    </xsl:template>
+    
     <xsl:template match="article-meta/contrib-group | front/contrib-group | front-stub/contrib-group">
-        <xsl:variable name="id"><xsl:if test="../../@article-type!='translation'"><xsl:value-of select="../../@id"/></xsl:if></xsl:variable>
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="modal-id"></xsl:apply-templates></xsl:variable>
         <div>
             <xsl:attribute name="class">contribGroup contribGroupAlignLeft</xsl:attribute>
             <xsl:apply-templates select="contrib" mode="article-meta-contrib"/>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-sub-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-sub-article.xsl
@@ -5,22 +5,30 @@
     <xsl:template match="article" mode="article-text-sub-articles">
         <xsl:apply-templates select="response[@xml:lang=$TEXT_LANG] | sub-article[@xml:lang=$TEXT_LANG and @article-type!='translation']"></xsl:apply-templates>
     </xsl:template>
-
-    <!--xsl:template match="front-stub/aff | article/*/front/aff |front-stub/history | article/*/front/history ">        
+    
+    
+    <xsl:template match="sub-article[@article-type!='translation']//subject | response//subject">
     </xsl:template>
     
-    <xsl:template match="front-stub//subject | article/*/front//subject">
+    
+    <xsl:template match="sub-article[@article-type!='translation']//subject | response//subject">
+        <h2><xsl:apply-templates select="*|text()"></xsl:apply-templates></h2>
      </xsl:template>
-    <xsl:template match="front-stub//article-title | article/*/front//article-title">
+    
+    <xsl:template match="sub-article[@article-type!='translation']//article-title | response//article-title">
         <h2>
             <xsl:apply-templates select="*|text()"></xsl:apply-templates>
         </h2>
     </xsl:template>
-    <xsl:template match="front-stub//trans-title | article/*/front//trans-title">
-        <h3>
+    <xsl:template match="sub-article[@article-type!='translation']//trans-title | response//trans-title">
+        <h2>
             <xsl:apply-templates select="*|text()"></xsl:apply-templates>
-        </h3>
-    </xsl:template-->
+        </h2>
+    </xsl:template>
+    <xsl:template match="sub-article[@article-type!='translation']//aff | response//aff">
+    </xsl:template>
+    <xsl:template match="sub-article[@article-type!='translation']//history | response//history">
+    </xsl:template>
     
     <xsl:template match="sub-article[@article-type!='translation'] | response">
         <div class="articleSection">

--- a/packtools/catalogs/htmlgenerator/v2.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article.xsl
@@ -94,6 +94,7 @@
                     <xsl:apply-templates select="." mode="article"/>
                     <xsl:apply-templates select="." mode="article-modals"/>
                 </div>
+                <xsl:if test="$graphic_elements_title!=''">
                 <ul class="floatingMenu fm-slidein" data-fm-toogle="hover">
                     <li class="fm-wrap">
                         <a href="javascript:;" class="fm-button-main">
@@ -109,7 +110,7 @@
                             	
                         </ul>
                     </li>
-                </ul>
+                </ul></xsl:if>
                 <xsl:comment> $q_abstract_title=<xsl:value-of select="$q_abstract_title"/></xsl:comment>
                 <xsl:comment> $q_abstract=<xsl:value-of select="$q_abstract"/></xsl:comment>
                 <xsl:comment> $q_front=<xsl:value-of select="$q_front"/></xsl:comment>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
@@ -2,6 +2,10 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
 
+    <xsl:template match="front | front-stub" mode="modal-id"><xsl:value-of select="../@id"/></xsl:template>
+    <xsl:template match="article-meta | sub-article[@article-type='translation']//front | sub-article[@article-type='translation']//front-stub" mode="modal-id">    
+    </xsl:template>
+    
     <xsl:variable name="xref_fn" select="$article//xref[@ref-type='fn']"></xsl:variable>
     
     <xsl:template match="article" mode="modal-contribs">
@@ -24,7 +28,7 @@
     
     <xsl:template match="article-meta | front | front-stub" mode="modal-contrib">
         <xsl:if test=".//contrib[*]">
-            <xsl:variable name="id"><xsl:if test="@article-type!='translation'"><xsl:value-of select="../@id"/></xsl:if></xsl:variable>
+            <xsl:variable name="id"><xsl:apply-templates select="." mode="modal-id"></xsl:apply-templates></xsl:variable>
             <div class="modal fade ModalDefault" id="ModalTutors{$id}" tabindex="-1" role="dialog" aria-hidden="true">            
                 
             <div class="modal-dialog">


### PR DESCRIPTION
• Título da seção "Reply", para cartas, não aparece configurado (aparece como parágrafo normal e com todos os títulos traduzidos como texto corrido, juntos); 
• Ao passar o mouse sobre o botão da boxmenu, aparece um campo vazio em azul-marinho ao lado da indicação de "figuras/tabelas"; 
